### PR TITLE
Add documentation link to tool's InfoCard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ data/providers_bq.csv
 htmlcov/
 coverage/*.xml
 .coverage
+*.code-workspace
+.venv/
 
 Pipfile
 Pipfile.lock

--- a/supply-chain/package.json
+++ b/supply-chain/package.json
@@ -7,8 +7,8 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop",
-    "start": "gatsby develop",
+    "develop": "gatsby develop -p 8530",
+    "start": "gatsby develop -p 8530",
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/supply-chain/src/components/dashboard.js
+++ b/supply-chain/src/components/dashboard.js
@@ -436,21 +436,26 @@ const Dashboard = () => {
 
   return (<AppWrapper>
     <div style={{maxWidth: "1500px"}}>
-    <InfoCard title={"Supply Chain Explorer"} description={
-      <div>
-        ETO's Supply Chain Explorer is designed to quickly orient non-experts to the essential inputs, players, and relationships involved in producing advanced computer chips. Use the Explorer to learn how these chips are made, who makes them, and the tools, materials, and processes involved in the supply chain.
-        <Typography component={"p"} variant={"body1"} style={{padding: "15px 0px"}}>
-        <strong>Learn more:</strong> <a href="https://eto.tech/tool-docs/chipexplorer" target="_blank" rel="noopener">Documentation</a><span style={{padding: "0px 10px"}}>|</span>Blog post: <a href="https://eto.tech/blog/five-takeaways-chip-supply-chain" target="_blank" rel="noopener">Five quick takeaways on the chip supply chain</a><span style={{padding: "0px 10px"}}>|</span>Blog post: <a href="https://eto.tech/blog/introducing-supply-chain-explorer-advanced-chips" target="_blank" rel="noopener">Introducing the Supply Chain Explorer</a>
-        </Typography>
-        <Typography component={"p"} variant={"body1"} style={{paddingBottom: "20px"}}>Last updated on {data.site.buildTime}. Underlying data originally published in 2021.</Typography>
-      </div>} sidebarTitle={"Quick guide"} sidebarContent={
-      <div>
-        <div>
-          <div style={{paddingBottom: "15px"}}>Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.</div>
-          <div>Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.</div>
-        </div>
-      </div>
-    } />
+      <InfoCard
+        title={"Supply Chain Explorer"}
+        description={
+          <div>
+            ETO's Supply Chain Explorer is designed to quickly orient non-experts to the essential inputs, players, and relationships involved in producing advanced computer chips. Use the Explorer to learn how these chips are made, who makes them, and the tools, materials, and processes involved in the supply chain.
+            <Typography component={"p"} variant={"body1"} style={{padding: "15px 0px"}}>
+            <strong>Learn more:</strong> <a href="https://eto.tech/tool-docs/chipexplorer" target="_blank" rel="noopener">Documentation</a><span style={{padding: "0px 10px"}}>|</span>Blog post: <a href="https://eto.tech/blog/five-takeaways-chip-supply-chain" target="_blank" rel="noopener">Five quick takeaways on the chip supply chain</a><span style={{padding: "0px 10px"}}>|</span>Blog post: <a href="https://eto.tech/blog/introducing-supply-chain-explorer-advanced-chips" target="_blank" rel="noopener">Introducing the Supply Chain Explorer</a>
+            </Typography>
+            <Typography component={"p"} variant={"body1"} style={{paddingBottom: "20px"}}>Last updated on {data.site.buildTime}. Underlying data originally published in 2021.</Typography>
+          </div>
+        }
+        documentationLink="https://eto.tech/tool-docs/chipexplorer/"
+        sidebarTitle={"Quick guide"}
+        sidebarContent={
+          <div>
+            <div style={{paddingBottom: "15px"}}>Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.</div>
+            <div>Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.</div>
+          </div>
+        }
+      />
     </div>
     <Paper style={{position: "sticky", top: "0px", zIndex: "20"}}
       className="filter-bar"


### PR DESCRIPTION
Add a link to the Supply Chain Explorer documentation in the introductory InfoCard element.

Also specified a standard port number and updated `.gitignore`