### PR TITLE
Add link checking step to CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         cd supply-chain
         find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:()-]+" {} \; | sort -u > linklist.txt
-        printf '%s\n%s\n' "# LinkChecker URL list" "$(cat linklist.txt)" > linklist.txt
+        printf '%s\n%s\n' "# LinkChecker URL list\n# <meta charset="UTF-8">" "$(cat linklist.txt)" > linklist.txt
         linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
         cat output.txt
         echo "link_check=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,9 @@ jobs:
         linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" -o failures > output.txt || true
         cat output.txt
         echo "num_links=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT
-        echo "links=$(cat output.txt)" >> $GITHUB_OUTPUT
+        echo "links<<EOFdelimiter" >> $GITHUB_OUTPUT
+        echo "$(cat output.txt)" >> $GITHUB_OUTPUT
+        echo "EOFdelimiter" >> $GITHUB_OUTPUT
     - name: Edit PR comment about link checking
       if: steps.link_check.outputs.num_links > 0
       uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       id: link_check
       run: |
         cd supply-chain
-        find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:()-]+" {} \; | sort -u > linklist.txt
+        find public -name "*.js" -exec grep -Eo "(http|https):\/\/[^\{\}\"'\\ ]+" {} \; | sort -u > linklist.txt
         printf '%s\n%s\n' "# LinkChecker URL list\n# <meta charset="UTF-8">" "$(cat linklist.txt)" > linklist.txt
         linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
         cat output.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    # - name: Test with pytest
-    #   run: |
-    #     coverage run -m pytest tests
-    #     coverage xml -o coverage/python.xml
-    # - name: Report python coverage
-    #   uses: orgoro/coverage@v3
-    #   with:
-    #     coverageFile: coverage/python.xml
-    #     token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Test with pytest
+      run: |
+        coverage run -m pytest tests
+        coverage xml -o coverage/python.xml
+    - name: Report python coverage
+      uses: orgoro/coverage@v3
+      with:
+        coverageFile: coverage/python.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Authenticate to Google Cloud'
       id: 'auth'
       uses: 'google-github-actions/auth@v1'
@@ -56,20 +56,20 @@ jobs:
         npm run artifactregistry-login
         npm install
         npm test -- --coverage --coverageReporters="json-summary" --coverageReporters="text" | tee ./coverage.txt
-    # - name: Report javascript coverage
-    #   uses: MishaKav/jest-coverage-comment@v1.0.23
-    #   with:
-    #     title: "JavaScript Coverage"
-    #     summary-title: "Summary"
-    #     coverage-title: "Modified Files"
-    #     github-token: ${{ secrets.GITHUB_TOKEN }}
-    #     report-only-changed-files: true
-    #     coverage-path: ./supply-chain/coverage.txt
-    #     coverage-summary-path: ./supply-chain/coverage/coverage-summary.json
-    #     coverage-path-prefix: supply-chain/src/
-    # - name: Run linting
-    #   run: |
-    #     pre-commit run --all-files
+    - name: Report javascript coverage
+      uses: MishaKav/jest-coverage-comment@v1.0.23
+      with:
+        title: "JavaScript Coverage"
+        summary-title: "Summary"
+        coverage-title: "Modified Files"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        report-only-changed-files: true
+        coverage-path: ./supply-chain/coverage.txt
+        coverage-summary-path: ./supply-chain/coverage/coverage-summary.json
+        coverage-path-prefix: supply-chain/src/
+    - name: Run linting
+      run: |
+        pre-commit run --all-files
     - name: Build output files
       run: |
         cd supply-chain
@@ -80,13 +80,15 @@ jobs:
         cd supply-chain
         find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:()-]+" {} \; | sort -u > linklist.txt
         printf '%s\n%s\n' "# LinkChecker URL list\n# <meta charset="UTF-8">" "$(cat linklist.txt)" > linklist.txt
-        linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
+        linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" -o failures > output.txt || true
         cat output.txt
-        echo "link_check=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT
+        echo "num_links=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT
+        echo "links=$(cat output.txt)" >> $GITHUB_OUTPUT
     - name: Edit PR comment about link checking
-      if: steps.link_check.outputs.link_check > 0
+      if: steps.link_check.outputs.num_links > 0
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          There are ${{ steps.link_check.outputs.link_check }} broken links. Check the output of the link check build step for details.
+          There are ${{ steps.link_check.outputs.num_links }} broken links. Check the code for these links:
+          ${{ steps.link_check.outputs.links }}
         comment_tag: link_check_msg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       id: link_check
       run: |
         cd supply-chain
-        find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]+" {} \; | sort -u > linklist.txt
+        find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:()-]+" {} \; | sort -u > linklist.txt
         printf '%s\n%s\n' "# LinkChecker URL list" "$(cat linklist.txt)" > linklist.txt
         linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
         cat output.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test with pytest
-      run: |
-        coverage run -m pytest tests
-        coverage xml -o coverage/python.xml
-    - name: Report python coverage
-      uses: orgoro/coverage@v3
-      with:
-        coverageFile: coverage/python.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Test with pytest
+    #   run: |
+    #     coverage run -m pytest tests
+    #     coverage xml -o coverage/python.xml
+    # - name: Report python coverage
+    #   uses: orgoro/coverage@v3
+    #   with:
+    #     coverageFile: coverage/python.xml
+    #     token: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Authenticate to Google Cloud'
       id: 'auth'
       uses: 'google-github-actions/auth@v1'
@@ -54,19 +54,39 @@ jobs:
         python3 scripts/preprocess.py
         cd supply-chain
         npm run artifactregistry-login
-        npm install --force
+        npm install
         npm test -- --coverage --coverageReporters="json-summary" --coverageReporters="text" | tee ./coverage.txt
-    - name: Report javascript coverage
-      uses: MishaKav/jest-coverage-comment@v1.0.23
-      with:
-        title: "JavaScript Coverage"
-        summary-title: "Summary"
-        coverage-title: "Modified Files"
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        report-only-changed-files: true
-        coverage-path: ./supply-chain/coverage.txt
-        coverage-summary-path: ./supply-chain/coverage/coverage-summary.json
-        coverage-path-prefix: supply-chain/src/
-    - name: Run linting
+    # - name: Report javascript coverage
+    #   uses: MishaKav/jest-coverage-comment@v1.0.23
+    #   with:
+    #     title: "JavaScript Coverage"
+    #     summary-title: "Summary"
+    #     coverage-title: "Modified Files"
+    #     github-token: ${{ secrets.GITHUB_TOKEN }}
+    #     report-only-changed-files: true
+    #     coverage-path: ./supply-chain/coverage.txt
+    #     coverage-summary-path: ./supply-chain/coverage/coverage-summary.json
+    #     coverage-path-prefix: supply-chain/src/
+    # - name: Run linting
+    #   run: |
+    #     pre-commit run --all-files
+    - name: Build output files
       run: |
-        pre-commit run --all-files
+        cd supply-chain
+        npm run build
+    - name: Check links in built files
+      id: link_check
+      run: |
+        cd supply-chain
+        find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]+" {} \; | sort -u > linklist.txt
+        printf '%s\n%s\n' "# LinkChecker URL list" "$(cat linklist.txt)" > linklist.txt
+        linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
+        cat output.txt
+        echo "link_check=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT
+    - name: Edit PR comment about link checking
+      if: steps.link_check.outputs.link_check > 0
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          There are ${{ steps.link_check.outputs.link_check }} broken links. Check the output of the link check build step for details.
+        comment_tag: link_check_msg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         cd supply-chain
         find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:()-]+" {} \; | sort -u > linklist.txt
         printf '%s\n%s\n' "# LinkChecker URL list\n# <meta charset="UTF-8">" "$(cat linklist.txt)" > linklist.txt
-        linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" -o failures > output.txt || true
+        linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" --ignore-url="https://.*\.mapbox\..*" -o failures > output.txt || true
         cat output.txt
         echo "num_links=$(wc -l < output.txt | sed 's/^ *//g')" >> $GITHUB_OUTPUT
         echo "links<<EOFdelimiter" >> $GITHUB_OUTPUT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jinja2
 kaleido
+linkchecker
 pdfkit
 plotly
 pycountry

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -79,7 +79,7 @@ class Preprocess:
                 if os.path.exists(args.output_images_dir):
                     shutil.rmtree(args.output_images_dir)
                 os.makedirs(args.output_images_dir)
-                self.mk_images(args.images_file, args.output_images_dir)
+            self.mk_images(args.images, args.images_file, args.output_images_dir)
 
             self.write_graphs(args.sequence, args.output_dir)
             self.mk_provider_to_meta(args.providers)
@@ -711,9 +711,10 @@ class Preprocess:
             r"<\/p>", "", re.sub(r"^<p>", "", mistletoe.markdown(text).strip())
         ).replace("a href=", "a target='_blank' rel='noopener' href=")
 
-    def mk_images(self, images_fi: str, output_dir: str) -> None:
+    def mk_images(self, download_images: bool, images_fi: str, output_dir: str) -> None:
         """
         Downloads images from an airtable CSV and renames them according to their associated node
+        :param download_images: True if images should be re-downloaded
         :param images_fi: Path to airtable CSV
         :param output_dir: Path to output folder where images will be placed
         :return: None
@@ -725,10 +726,11 @@ class Preprocess:
                 image_fi = re.search(r"\((http.*?)\)", image_col)[1]
                 file_type = image_fi.split(".")[-1]
                 image_node_id = line["input_id"]
-                urllib.request.urlretrieve(
-                    image_fi,
-                    os.path.join(output_dir, image_node_id) + f".{file_type}",
-                )
+                if download_images:
+                    urllib.request.urlretrieve(
+                        image_fi,
+                        os.path.join(output_dir, image_node_id) + f".{file_type}",
+                    )
                 self.node_to_meta[image_node_id]["image_caption"] = self.clean_md_link(
                     line["caption"]
                 )


### PR DESCRIPTION
I've made the link-checking step a non-blocking step. If any links are failing, the pipeline will add a comment to the PR but will otherwise succeed. There are no real failing links in this repo, but I've left the failing comment here so you can see what it looks like. In real life, we would just delete this after resolving all errors. 

Explanation of commands used: 
- `find public -name "*.js" -exec grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]+" {} \; | sort -u > linklist.txt`: Find all built javascript files, grep for all URLs using the given regex, sort and deduplicate those URLs, and store them in `linklist.txt`
- `printf '%s\n%s\n' "# LinkChecker URL list" "$(cat linklist.txt)" > linklist.txt`: Add a comment to the top of the output file so that the linkchecker works 
- `linkchecker linklist.txt --check-extern --ignore-url="https://.*\.fastly\.net/.*" -o failures > output.txt || true`: Use the link checker to check each URL in the output file. Ignore the given regexes (we can add to this to ignore more files). Put all failing links in `output.txt`. Return a successful exit code no matter what because we want this pipeline to succeed. 
- `cat output.txt`: Print all failing links so that we can look at them later. 
- `echo $(wc -l < output.txt) >> $GITHUB_OUTPUT`: Store the number of failing links so we can put it in a PR comment. 

List of links being checked: 
[linklist.txt](https://github.com/georgetown-cset/eto-supply-chain/files/12613025/linklist.txt)